### PR TITLE
Remove border styles for "No Todos"

### DIFF
--- a/src/styles/modules/app.module.scss
+++ b/src/styles/modules/app.module.scss
@@ -26,9 +26,6 @@
 	color: var(--black-2);
 	text-align: center;
 	margin: 0 auto;
-	padding: 0.5rem 1rem;
-	border-radius: 8px;
-	background-color: var(--gray-2);
 	width: max-content;
 	height: auto;
 }


### PR DESCRIPTION
# Description

- Removed border styles for "No Todos" as Having "No ToDos" indicator text already contained in a bordered component seems not to need to have a border itself for better aesthetics.

Closes #2

## Type of change

- [x] Updating  Existing feature (non-breaking change which adds functionality)

# How Has This Been Tested?

* "No ToDos" with border
![Screenshot (28)](https://user-images.githubusercontent.com/68426990/190920391-881b325a-e677-4e7c-acaf-cc18d3fb70ad.png)


* "No ToDos" without border
![Screenshot (27)](https://user-images.githubusercontent.com/68426990/190920441-a3d58771-23fd-416d-b6e3-45f2cf98436b.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
