### PR TITLE
Fix : duplicate tasks issue on "Add Task" button

### DIFF
--- a/src/components/TodoModal.js
+++ b/src/components/TodoModal.js
@@ -34,6 +34,7 @@ function TodoModal({ type, modalOpen, setModalOpen, todo }) {
   const dispatch = useDispatch();
   const [title, setTitle] = useState('');
   const [status, setStatus] = useState('incomplete');
+  const [isSubmitted, setIsSubmitted] = useState(false);
 
   useEffect(() => {
     if (type === 'update' && todo) {
@@ -60,7 +61,8 @@ function TodoModal({ type, modalOpen, setModalOpen, todo }) {
             status,
             time: format(new Date(), 'p, MM/dd/yyyy'),
           })
-        );
+        ); 
+        setIsSubmitted(true);
         toast.success('Task added successfully');
       }
       if (type === 'update') {
@@ -131,7 +133,7 @@ function TodoModal({ type, modalOpen, setModalOpen, todo }) {
                 </select>
               </label>
               <div className={styles.buttonContainer}>
-                <Button type="submit" variant="primary">
+                <Button type="submit" variant="primary" disabled={!isSubmitted}>
                   {type === 'add' ? 'Add Task' : 'Update Task'}
                 </Button>
                 <Button variant="secondary" onClick={() => setModalOpen(false)}>


### PR DESCRIPTION
Hi Shaif,

I've fixed a small bug in the todo app where clicking the "Add Task" button multiple times would create duplicate tasks. I've added a state variable to track whether or not the user has submitted the task, and disabled the button until the user submits the task.

I've tested the fix by reproducing the issue and verifying that it is no longer possible to create duplicate tasks.

Please review my changes and let me know if you have any questions or concerns.

Thanks,
Ahmod Hasan